### PR TITLE
Sort pageitems before searching for correct package version (#709)

### DIFF
--- a/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
+++ b/src/NuGetForUnity/Editor/PackageSource/NugetApiClientV3.cs
@@ -488,6 +488,8 @@ namespace NugetForUnity.PackageSource
                 pageItem.items = await GetRegistrationPageLeafItems(packageSource, pageItem, cancellationToken).ConfigureAwait(false);
             }
 
+            pageItem.items = pageItem.items.OrderBy(leaf => new NugetPackageVersion(leaf.CatalogEntry.version)).ToList();
+
             var leafItem = getLatestVersion ?
                 pageItem.items.OrderByDescending(registrationLeaf => new NugetPackageVersion(registrationLeaf.CatalogEntry.version))
                     .FirstOrDefault() :


### PR DESCRIPTION
Attempt to fix issue where some nuget packages would forcibly update themselves to a higher version when performing a restore on the command line.